### PR TITLE
Replaced the Image selection dialog with a searchable ListSelectionView

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,10 @@ base {
     group = "io.github.qupath"
 }
 ext.qupathVersion = gradle.ext.qupathVersion
-ext.qupathJavaVersion = 17
+ext.qupathJavaVersion = libs.versions.jdk.get() as Integer
 
 dependencies {
+    implementation libs.qupath.fxtras
     shadow "io.github.qupath:qupath-gui-fx:${qupathVersion}"
     shadow "org.slf4j:slf4j-api:1.7.30"
 }
@@ -53,4 +54,8 @@ java {
     }
     withSourcesJar()
     withJavadocJar()
+}
+
+javafx {
+    modules = ["javafx.base", "javafx.swing", "javafx.controls", "javafx.graphics"]
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 rootProject.name = 'qupath-extension-align'
 
-gradle.ext.qupathVersion = "0.5.0"
+gradle.ext.qupathVersion = "0.6.0-SNAPSHOT"
 
 dependencyResolutionManagement {
 


### PR DESCRIPTION
This is just a small enhancement in UX, which I wanted to keep separate from my other PR.

It replaces the image selection box in qupath-extension-align with a ListSelectionView, which is searchable. For large projects with many entries (patient IDs), the search facility has been really helpful for finding matching images.

![image](https://github.com/qupath/qupath-extension-align/assets/3523902/0487c954-3d51-458f-bf0a-bd338b02c28c)

I've tested both my PRs separately and together.

Here's the post I made which describes the changes in more details: https://forum.image.sc/t/improving-the-qupath-extension-align-ui-hopefully/67390

Cheers,
Egor