### PR TITLE
Autoscale the affine transform when viewer and overlay images have different pixel sizes.

### DIFF
--- a/src/main/java/qupath/ext/align/gui/ImageAlignmentPane.java
+++ b/src/main/java/qupath/ext/align/gui/ImageAlignmentPane.java
@@ -370,10 +370,7 @@ public class ImageAlignmentPane {
 		Button btnReset = new Button("Reset");
 		btnReset.setOnAction(e -> {
 			var overlay = getSelectedOverlay();
-			var affine = overlay == null ? null : overlay.getAffine();
-			if (affine == null)
-				return;
-			affine.setToIdentity();
+			overlay.resetAffine();
 		});
 		Button btnInvert = new Button("Invert");
 		btnInvert.setOnAction(e -> {

--- a/src/main/java/qupath/ext/align/gui/ImageAlignmentPane.java
+++ b/src/main/java/qupath/ext/align/gui/ImageAlignmentPane.java
@@ -370,6 +370,8 @@ public class ImageAlignmentPane {
 		Button btnReset = new Button("Reset");
 		btnReset.setOnAction(e -> {
 			var overlay = getSelectedOverlay();
+			if (overlay == null)
+				return;
 			overlay.resetAffine();
 		});
 		Button btnInvert = new Button("Invert");

--- a/src/main/java/qupath/ext/align/gui/ImageServerOverlay.java
+++ b/src/main/java/qupath/ext/align/gui/ImageServerOverlay.java
@@ -61,13 +61,31 @@ public class ImageServerOverlay extends AbstractOverlay {
 	private AffineTransform transform;
 	private AffineTransform transformInverse;
 	
+    	/**
+     	* Helper method to calculate the Affine transformation based on pixel sizes.
+     	*/
+    	private static Affine calculateAffine(QuPathViewer viewer, ImageServer<BufferedImage> server) {
+            // Access the PixelCalibration from the viewer
+            PixelCalibration viewerCalibration = viewer.getImageData().getServer().getPixelCalibration();
+
+            // Access the PixelCalibration from the server
+            PixelCalibration serverCalibration = server.getPixelCalibration();
+
+            // Calculate the a and y scaling factor
+            double mxx = viewerCalibration.getPixelWidthMicrons() / serverCalibration.getPixelWidthMicrons();
+            double myy = viewerCalibration.getPixelHeightMicrons() / serverCalibration.getPixelHeightMicrons();
+
+            // Create and return the Affine object
+            return new Affine(mxx, 0, 0, 0, myy, 0);
+        }
+	
 	/**
 	 * Constructor.
 	 * @param viewer viewer to which the overlay should be added
 	 * @param server ImageServer that should be displayed on the overlay
 	 */
 	public ImageServerOverlay(final QuPathViewer viewer, final ImageServer<BufferedImage> server) {
-		this(viewer, server, new Affine());
+		this(viewer, server, calculateAffine(viewer, server));
 	}
 	
 	/**

--- a/src/main/java/qupath/ext/align/gui/ImageServerOverlay.java
+++ b/src/main/java/qupath/ext/align/gui/ImageServerOverlay.java
@@ -26,6 +26,7 @@ import java.awt.RenderingHints;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.NoninvertibleTransformException;
 import java.awt.image.BufferedImage;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,9 +87,9 @@ public class ImageServerOverlay extends AbstractOverlay {
 		this.server = server;
 		this.transform = new AffineTransform();
 		this.transformInverse = null;//transform.createInverse();
-		
+		// Request repaint any time the transform changes
 		this.affine = affine;
-		// Access the PixelCalibration from the viewer and server and
+		// Access the PixelCalibration from the current viewer and overlay server and
 		// reset the affine transform to a scaled identity
 		this.viewerImageCalibration = viewer.getImageData().getServer().getPixelCalibration();
 		this.overlayImageCalibration = server.getPixelCalibration();

--- a/src/main/java/qupath/ext/align/gui/ImageServerOverlay.java
+++ b/src/main/java/qupath/ext/align/gui/ImageServerOverlay.java
@@ -131,12 +131,18 @@ public class ImageServerOverlay extends AbstractOverlay {
 	 * Reset the affine transform to its pixel-correct scaled identity
 	 */
 	public void resetAffine() {
+		// The scaling factors's defaults
+		double mxx = 1;
+		double myy = 1;
+
 		if (this.affine == null)
 			return;
 
-        // Calculate the a and y scaling factor
-        double mxx = this.viewerImageCalibration.getPixelWidthMicrons() / overlayImageCalibration.getPixelWidthMicrons();
-        double myy = this.viewerImageCalibration.getPixelHeightMicrons() / overlayImageCalibration.getPixelHeightMicrons();
+        // Calculate the affine 'a' and 'y' scaling factor parameters - Defaults to 1 and 1 if no pixel size micron available.
+		if (this.viewerImageCalibration.hasPixelSizeMicrons() && this.overlayImageCalibration.hasPixelSizeMicrons()) {
+			mxx = this.viewerImageCalibration.getPixelWidthMicrons() / overlayImageCalibration.getPixelWidthMicrons();
+			myy = this.viewerImageCalibration.getPixelHeightMicrons() / overlayImageCalibration.getPixelHeightMicrons();
+		}
 
 		this.affine.setToTransform(mxx, 0, 0, 0, myy, 0);
 	}

--- a/src/main/java/qupath/ext/align/gui/ImageServerOverlay.java
+++ b/src/main/java/qupath/ext/align/gui/ImageServerOverlay.java
@@ -39,6 +39,7 @@ import qupath.lib.gui.viewer.overlays.AbstractOverlay;
 import qupath.lib.gui.viewer.overlays.PathOverlay;
 import qupath.lib.images.ImageData;
 import qupath.lib.images.servers.ImageServer;
+import qupath.lib.images.servers.PixelCalibration;
 import qupath.lib.regions.ImageRegion;
 
 /**
@@ -60,24 +61,9 @@ public class ImageServerOverlay extends AbstractOverlay {
 	
 	private AffineTransform transform;
 	private AffineTransform transformInverse;
-	
-    	/**
-     	* Helper method to calculate the Affine transformation based on pixel sizes.
-     	*/
-    	private static Affine calculateAffine(QuPathViewer viewer, ImageServer<BufferedImage> server) {
-            // Access the PixelCalibration from the viewer
-            PixelCalibration viewerCalibration = viewer.getImageData().getServer().getPixelCalibration();
 
-            // Access the PixelCalibration from the server
-            PixelCalibration serverCalibration = server.getPixelCalibration();
-
-            // Calculate the a and y scaling factor
-            double mxx = viewerCalibration.getPixelWidthMicrons() / serverCalibration.getPixelWidthMicrons();
-            double myy = viewerCalibration.getPixelHeightMicrons() / serverCalibration.getPixelHeightMicrons();
-
-            // Create and return the Affine object
-            return new Affine(mxx, 0, 0, 0, myy, 0);
-        }
+	private PixelCalibration viewerCalibration;
+	private PixelCalibration serverCalibration;
 	
 	/**
 	 * Constructor.
@@ -85,7 +71,7 @@ public class ImageServerOverlay extends AbstractOverlay {
 	 * @param server ImageServer that should be displayed on the overlay
 	 */
 	public ImageServerOverlay(final QuPathViewer viewer, final ImageServer<BufferedImage> server) {
-		this(viewer, server, calculateAffine(viewer, server));
+		this(viewer, server, new Affine());
 	}
 	
 	/**
@@ -100,8 +86,15 @@ public class ImageServerOverlay extends AbstractOverlay {
 		this.server = server;
 		this.transform = new AffineTransform();
 		this.transformInverse = null;//transform.createInverse();
-		// Request repaint any time the transform changes
+		
 		this.affine = affine;
+		// Access the PixelCalibration from the viewer and server and
+		// reset the affine transform to a scaled identity
+		this.viewerCalibration = viewer.getImageData().getServer().getPixelCalibration();
+		this.serverCalibration = server.getPixelCalibration();
+		resetAffine();
+		
+		// Request repaint any time the transform changes
 		this.affine.addEventHandler(TransformChangedEvent.ANY, e ->  {
 			updateTransform();
 			viewer.repaintEntireImage();
@@ -133,7 +126,21 @@ public class ImageServerOverlay extends AbstractOverlay {
 	public Affine getAffine() {
 		return affine;
 	}
-	
+
+	/**
+	 * Reset the affine transform to its pixel-correct scaled identity
+	 */
+	public void resetAffine() {
+		if (this.affine == null)
+			return;
+
+        // Calculate the a and y scaling factor
+        double mxx = this.viewerCalibration.getPixelWidthMicrons() / serverCalibration.getPixelWidthMicrons();
+        double myy = this.viewerCalibration.getPixelHeightMicrons() / serverCalibration.getPixelHeightMicrons();
+
+		this.affine.setToTransform(mxx, 0, 0, 0, myy, 0);
+	}
+		
 	private void updateTransform() {
 		transform.setTransform(
 			affine.getMxx(),

--- a/src/main/java/qupath/ext/align/gui/ImageServerOverlay.java
+++ b/src/main/java/qupath/ext/align/gui/ImageServerOverlay.java
@@ -62,8 +62,8 @@ public class ImageServerOverlay extends AbstractOverlay {
 	private AffineTransform transform;
 	private AffineTransform transformInverse;
 
-	private PixelCalibration viewerCalibration;
-	private PixelCalibration serverCalibration;
+	private PixelCalibration viewerImageCalibration;
+	private PixelCalibration overlayImageCalibration;
 	
 	/**
 	 * Constructor.
@@ -90,8 +90,8 @@ public class ImageServerOverlay extends AbstractOverlay {
 		this.affine = affine;
 		// Access the PixelCalibration from the viewer and server and
 		// reset the affine transform to a scaled identity
-		this.viewerCalibration = viewer.getImageData().getServer().getPixelCalibration();
-		this.serverCalibration = server.getPixelCalibration();
+		this.viewerImageCalibration = viewer.getImageData().getServer().getPixelCalibration();
+		this.overlayImageCalibration = server.getPixelCalibration();
 		resetAffine();
 		
 		// Request repaint any time the transform changes
@@ -135,8 +135,8 @@ public class ImageServerOverlay extends AbstractOverlay {
 			return;
 
         // Calculate the a and y scaling factor
-        double mxx = this.viewerCalibration.getPixelWidthMicrons() / serverCalibration.getPixelWidthMicrons();
-        double myy = this.viewerCalibration.getPixelHeightMicrons() / serverCalibration.getPixelHeightMicrons();
+        double mxx = this.viewerImageCalibration.getPixelWidthMicrons() / overlayImageCalibration.getPixelWidthMicrons();
+        double myy = this.viewerImageCalibration.getPixelHeightMicrons() / overlayImageCalibration.getPixelHeightMicrons();
 
 		this.affine.setToTransform(mxx, 0, 0, 0, myy, 0);
 	}


### PR DESCRIPTION
Hello,

this pull request is for calculating a scaling factor between viewer and overlay images if their pixel size is different, and apply it to the transform matrix.

This issue (aligning images with different pixel sizes) was discussed on the forum:
https://forum.image.sc/t/align-tool-difference-in-pixel-size-for-the-fixed-and-moving-images-is-not-accounted-for/95973

Scaling can occur when a new overlay is selected and when the reset button is pressed. The new code handles both scenarios.

Cheers,
Egor